### PR TITLE
fix typo in README template for services

### DIFF
--- a/mypy_boto3_builder/templates/boto3_service_docs/README.md.jinja2
+++ b/mypy_boto3_builder/templates/boto3_service_docs/README.md.jinja2
@@ -21,7 +21,7 @@ from {{ package.library_name }}.session import Session
 from {{ package.name }}.client import {{ package.client.name }}
 
 def get_client() -> {{ package.client.name }}:
-    return Session().cleint("{{ service_name.boto3_name }}")
+    return Session().client("{{ service_name.boto3_name }}")
 ```
 
 {% if package.paginators %}


### PR DESCRIPTION
Change `cleint` -> `client`

### Notes

Fix typo in documentation templates

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

All of these are optional:

- [X] I have performed a self-review of my own code
- [ ] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project
- [ ] I have tested my code changes

Very minor change - no testing or pre-commit needed
