### PR TITLE
Fixed BuiltConditionExpression.attribute_value_placeholders type to a Dict

### DIFF
--- a/mypy_boto3_builder/boto3_stubs_static/dynamodb/conditions.pyi
+++ b/mypy_boto3_builder/boto3_stubs_static/dynamodb/conditions.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, List, NamedTuple, Pattern
+from typing import Any, Dict, List, NamedTuple, Pattern
 
 if sys.version_info >= (3, 9):
     from typing import Literal, TypedDict
@@ -125,7 +125,7 @@ BuiltConditionExpression = NamedTuple(
     [
         ("condition_expression", str),
         ("attribute_name_placeholders", List[str]),
-        ("attribute_value_placeholders", List[str]),
+        ("attribute_value_placeholders", Dict[str, Any]),
     ],
 )
 


### PR DESCRIPTION
### Notes

Thanks for a very useful project! I'm pretty sure `BuiltConditionExpression.attribute_value_placeholders` was mistyped, so I fixed it.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

All of these are optional:

- [x] I have performed a self-review of my own code
- [x] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project
- [x] I have tested my code changes

Thank you!
