### PR TITLE
Fix product parameter help message

### DIFF
--- a/mypy_boto3_builder/constants.py
+++ b/mypy_boto3_builder/constants.py
@@ -74,7 +74,7 @@ class Product(Enum):
     aioboto3_docs = "aioboto3-docs"
 
     def __str__(self) -> str:
-        return self.name
+        return self.value
 
     def get_library(self) -> ProductLibrary:
         """


### PR DESCRIPTION
### Notes

Currently `mypy_boto3-builder -h` shows these choices for `--product` parameter:
```
{boto3,boto3_services,boto3_docs,aiobotocore,aiobotocore_services,aiobotocore_docs,aioboto3,aioboto3_docs} [{boto3,boto3_services,boto3_docs,aiobotocore,aiobotocore_services,aiobotocore_docs,aioboto3,aioboto3_docs} ...]
```

But it really expects input with `-` instead of `-`. This PR should fix it. 
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

All of these are optional:

- [x] I have performed a self-review of my own code
- [x] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project
- [x] I have tested my code changes
