### PR TITLE
Adjust no-smart-version option to enable offline builds

### DIFF
--- a/mypy_boto3_builder/cli_parser.py
+++ b/mypy_boto3_builder/cli_parser.py
@@ -76,8 +76,12 @@ def parse_args(args: Sequence[str]) -> Namespace:
     )
     parser.add_argument(
         "--no-smart-version",
-        action="store_true",
-        help="Disable version bump if package is already published",
+        action="store_false",
+        help=(
+            "Disable version bump based od last PyPI version. "
+            "Set this flag to run packages build in offline mode. "
+            "skip-published flag is ignored in this case."
+        ),
     )
     parser.add_argument(
         "--panic",

--- a/mypy_boto3_builder/generators/base_generator.py
+++ b/mypy_boto3_builder/generators/base_generator.py
@@ -27,7 +27,7 @@ class BaseGenerator(ABC):
         output_path -- Path to write generated files
         generate_setup -- Whether to create package or installed module
         skip_published -- Whether to skip packages that are already published
-        disable_smart_version -- Whether to create a new postrelease if version is already published
+        disable_smart_version -- Whether to create a new postrelease based on latest PyPI version
         version -- Package build version
     """
 
@@ -68,6 +68,8 @@ class BaseGenerator(ABC):
         raise NotImplementedError()
 
     def _get_package_version(self, pypi_name: str, version: str) -> str | None:
+        if self.disable_smart_version:
+            return version
         pypi_manager = PyPIManager(pypi_name)
         if not pypi_manager.has_version(version):
             return version
@@ -75,8 +77,6 @@ class BaseGenerator(ABC):
         if self.skip_published:
             self.logger.info(f"Skipping {pypi_name} {version}, already on PyPI")
             return None
-        if self.disable_smart_version:
-            return version
 
         return pypi_manager.get_next_version(version)
 


### PR DESCRIPTION
### Notes

There are use cases, in which some might benefit from building stub packages from source, without making PyPI requests. Currently, any cli options combination allows you to achieve it.

This PR introduces a adjustment of `no-smart-version` option to serve these purpose
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

All of these are optional:

- [x] I have performed a self-review of my own code
- [x] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project
- [x] I have tested my code changes
