### PR TITLE
Add support for unpack kwargs

### DIFF
--- a/mypy_boto3_builder/structures/method.py
+++ b/mypy_boto3_builder/structures/method.py
@@ -2,6 +2,8 @@
 Class method.
 """
 
+from typing import Iterator
+
 from mypy_boto3_builder.structures.argument import Argument
 from mypy_boto3_builder.structures.function import Function
 
@@ -11,12 +13,49 @@ class Method(Function):
     Class method.
     """
 
-    @property
-    def call_arguments(self) -> list[Argument]:
+    def get_self_argument(self) -> Argument | None:
         """
-        Arguments that are used in method call.
+        Get `self` or `cls` argument.
         """
-        if self.arguments and self.arguments[0].name in ("self", "cls"):
-            return self.arguments[1:]
+        if not self.arguments:
+            return None
+        first_argument = self.arguments[0]
+        if first_argument.name in ("self", "cls"):
+            return first_argument
 
-        return self.arguments
+        return None
+
+    def iterate_call_arguments(self) -> Iterator[Argument]:
+        """
+        Iterate over arguments that are used in method call.
+        """
+        self_argument = self.get_self_argument()
+        for argument in super().iterate_call_arguments():
+            if argument == self_argument:
+                continue
+            yield argument
+
+    def iterate_packed_arguments(self) -> Iterator[Argument]:
+        """
+        Iterate over packed arguments for KW-only methods.
+        """
+        packed_arguments = super().iterate_packed_arguments()
+        if not self.is_kw_only() or not self.request_type_annotation:
+            yield from packed_arguments
+            return
+
+        self_argument = self.get_self_argument()
+        if self_argument:
+            yield self_argument
+
+        yield from packed_arguments
+
+    def has_arguments(self) -> bool:
+        """
+        Whether method has arguments.
+        """
+        self_argument = self.get_self_argument()
+        if not self_argument:
+            return super().has_arguments()
+
+        return len(self.arguments) > 1

--- a/mypy_boto3_builder/templates/common/function.py.jinja2
+++ b/mypy_boto3_builder/templates/common/function.py.jinja2
@@ -5,7 +5,7 @@
 {% if function.type_ignore -%}{{ '  # type: ignore' -}}{% endif -%}
 {{ '\n' -}}
 {% filter indent(4, True) -%}
-    {% for argument in function.arguments -%}
+    {% for argument in function.iterate_packed_arguments() -%}
         {% include "common/argument.py.jinja2" with context -%}
         {{ ",\n" if not loop.last else "\n" -}}
     {% endfor -%}

--- a/mypy_boto3_builder/templates/common/method.md.jinja2
+++ b/mypy_boto3_builder/templates/common/method.md.jinja2
@@ -2,12 +2,12 @@
 Asynchronous method. Use `await {{ method.name }}(...)` for a synchronous call.
 {% endif %}
 
-{% if method.call_arguments %}
+{% if method.has_arguments() %}
 {% if method.request_type_annotation %}
 Arguments mapping described in {% with type_annotation=method.request_type_annotation %}{% include "common/type_annotation.md.jinja2" with context -%}{% endwith -%}.
 {% endif %}
 {% if method.is_kw_only() %}Keyword-only arguments:{% else %}Arguments:{% endif %}
-{% with arguments=method.arguments[1:] -%}
+{% with arguments=method.iterate_call_arguments() -%}
 {% include "common/arguments_list.md.jinja2" with context -%}
 {% endwith %}
 {% endif %}

--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -56,11 +56,16 @@ class TestFunction:
         assert self.function.is_kw_only() is False
 
         self.function.arguments = [
-            Argument("self", None),
             Argument.kwflag(),
             Argument("lst", Type.ListAny),
         ]
         assert self.function.is_kw_only() is True
+
+        self.function.arguments = [
+            Argument("lst", Type.ListAny),
+            Argument.kwflag(),
+        ]
+        assert self.function.is_kw_only() is False
 
     def test_type_hint_annotations(self) -> None:
         assert self.function.type_hint_annotations == []
@@ -90,6 +95,14 @@ class TestFunction:
         }
 
     def test_remove_argument(self) -> None:
-        assert len(self.function.copy().remove_argument("unknown").arguments) == 3
-        assert len(self.function.copy().remove_argument("my_str").arguments) == 2
-        assert len(self.function.copy().remove_argument("my_str", "lst").arguments) == 1
+        test_function = self.function.copy()
+        test_function.remove_argument("unknown")
+        assert len(test_function.arguments) == 3
+
+        test_function = self.function.copy()
+        test_function.remove_argument("my_str")
+        assert len(test_function.arguments) == 2
+
+        test_function = self.function.copy()
+        test_function.remove_argument("my_str", "lst")
+        assert len(test_function.arguments) == 1

--- a/tests/structures/test_method.py
+++ b/tests/structures/test_method.py
@@ -1,26 +1,71 @@
 from mypy_boto3_builder.structures.argument import Argument
 from mypy_boto3_builder.structures.method import Method
 from mypy_boto3_builder.type_annotations.type import Type
+from mypy_boto3_builder.type_annotations.type_constant import TypeConstant
 
 
 class TestMethod:
-    def test_init(self) -> None:
-        method = Method(
-            "my_method",
-            [
+    method: Method
+
+    def setup_method(self):
+        self.method = Method(
+            name="name",
+            arguments=[
                 Argument("self", None),
-                Argument("second", Type.str),
-                Argument("other", Type.DictStrAny),
+                Argument("my_str", Type.str, TypeConstant("test")),
+                Argument("lst", Type.ListAny),
             ],
-            Type.none,
+            decorators=[Type.Any],
+            return_type=Type.none,
+            body_lines=["line1", "line2"],
+            docstring="docstring\n\nlong",
         )
-        assert len(method.call_arguments) == 2
-        method = Method(
-            "my_method",
-            [
-                Argument("second", Type.str),
-                Argument("other", Type.DictStrAny),
-            ],
-            Type.none,
-        )
-        assert len(method.call_arguments) == 2
+
+    def test_is_kw_only(self) -> None:
+        assert self.method.is_kw_only() is False
+
+        self.method.arguments = [
+            Argument("self", None),
+            Argument.kwflag(),
+            Argument("lst", Type.ListAny),
+        ]
+        assert self.method.is_kw_only() is True
+
+        self.method.arguments = [
+            Argument("self", None),
+            Argument("lst", Type.ListAny),
+            Argument.kwflag(),
+            Argument("lst2", Type.ListAny),
+        ]
+        assert self.method.is_kw_only() is False
+
+    def test_iterate_call_arguments(self) -> None:
+        assert len(list(self.method.iterate_call_arguments())) == 2
+
+        self.method.arguments = [
+            Argument("lst", Type.ListAny),
+            Argument.kwflag(),
+            Argument("lst2", Type.ListAny),
+        ]
+        assert len(list(self.method.iterate_call_arguments())) == 3
+
+    def test_iterate_packed_arguments(self) -> None:
+        assert len(list(self.method.iterate_packed_arguments())) == 3
+
+        self.method.arguments = [
+            Argument("self", None),
+            Argument.kwflag(),
+            Argument("lst2", Type.ListAny),
+        ]
+        assert len(list(self.method.iterate_packed_arguments())) == 3
+        self.method.create_request_type_annotation("RequestType")
+        assert len(list(self.method.iterate_packed_arguments())) == 2
+
+    def test_has_arguments(self) -> None:
+        assert self.method.has_arguments() is True
+
+        self.method.arguments = [Argument("self", None)]
+        assert self.method.has_arguments() is False
+
+        self.method.arguments = [Argument("other", Type.str)]
+        assert self.method.has_arguments() is True


### PR DESCRIPTION
### Changed
- `[builder]` Keyword-only methods use `**kwargs: Unpack[RequestTypeDef]` syntax
- `[builder]` Decreased generated service packages size by ~20%

### Fixed
- `[builder]` Keyword-only methods detection logic is more robust