### PR TITLE
Make typing_extensions a hard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "mdformat",
     "packaging",
     "setuptools",
+    "typing_extensions",
     "requests",
 ]
 
@@ -37,7 +38,6 @@ check = ["boto3-stubs", "types-aiobotocore", "types-aioboto3"]
 
 [tool.uv]
 dev-dependencies = [
-    "typing_extensions",
     "cryptography",
     "types-requests",
     "requests-mock",


### PR DESCRIPTION
It's used in
https://github.com/youtype/mypy_boto3_builder/blob/672ab31ea99510eb7f2cf8e39421a0fc6f1a2dcf/mypy_boto3_builder/utils/type_checks.py#L5

I updated https://github.com/conda-forge/mypy_boto3_builder-feedstock/pull/132 to reflect the dependencies here, and now it's failing.

### Notes

Please describe your changes here.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

All of these are optional:

- [ ] I have performed a self-review of my own code
- [ ] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project
- [ ] I have tested my code changes

Thank you!
