### PR TITLE
Add find_type_annotation_parent_map, faster implementation of find_ty…

### DIFF
--- a/mypy_boto3_builder/parsers/shape_parser.py
+++ b/mypy_boto3_builder/parsers/shape_parser.py
@@ -77,6 +77,7 @@ from mypy_boto3_builder.utils.strings import (
     get_type_def_name,
     xform_name,
 )
+from mypy_boto3_builder.utils.type_checks import is_union
 
 
 class ShapeParser:
@@ -1309,8 +1310,11 @@ class ShapeParser:
             )
             for type_annotation in parent_type_annotations:
                 parents = type_annotation.find_type_annotation_parents(input_typed_dict)
+                if not parents:
+                    continue
+
                 for parent in sorted(parents):
-                    if parent is union_type_annotation:
+                    if is_union(parent) and parent.name == union_name:
                         continue
                     self.logger.debug(
                         f"Adding output shape to {parent.render()} type:"

--- a/tests/type_annotations/test_type_subscript.py
+++ b/tests/type_annotations/test_type_subscript.py
@@ -55,6 +55,13 @@ class TestTypeSubscript:
         assert outer.find_type_annotation_parents(Type.str) == {outer}
         assert outer.find_type_annotation_parents(Type.List) == set()
 
+    def test_find_type_annotation_parent_map(self) -> None:
+        inner = TypeSubscript(Type.List, [Type.int])
+        outer = TypeSubscript(Type.Dict, [Type.str, inner])
+        assert outer.find_type_annotation_parent_map([Type.int]) == {Type.int: {inner}}
+        assert outer.find_type_annotation_parent_map([Type.str]) == {Type.str: {outer}}
+        assert outer.find_type_annotation_parent_map([Type.List]) == {}
+
     def test_replace_child(self) -> None:
         inner = TypeSubscript(Type.List, [Type.int])
         outer = TypeSubscript(Type.Dict, [Type.str, inner])


### PR DESCRIPTION
### Changed
- `[builder]` Optimized type replacement (e.g. `quicksight` parsing is now 10 times faster)