### PR TITLE
Use lazy request type annotation

### DIFF
--- a/mypy_boto3_builder/structures/client.py
+++ b/mypy_boto3_builder/structures/client.py
@@ -100,7 +100,7 @@ class Client(ClassRecord):
         Get a nice method with return TypedDict for documentation.
         """
         for method in self.methods:
-            if not method.request_type_annotation:
+            if not method.has_request_type_annotation():
                 continue
             if not method.return_type:
                 continue

--- a/mypy_boto3_builder/structures/method.py
+++ b/mypy_boto3_builder/structures/method.py
@@ -4,11 +4,10 @@ Class method.
 Copyright 2024 Vlad Emelianov
 """
 
-from collections.abc import Generator, Iterator
+from collections.abc import Iterator
 
 from mypy_boto3_builder.structures.argument import Argument
 from mypy_boto3_builder.structures.function import Function
-from mypy_boto3_builder.type_annotations.fake_annotation import FakeAnnotation
 
 
 class Method(Function):
@@ -43,7 +42,7 @@ class Method(Function):
         Iterate over packed arguments for KW-only methods.
         """
         packed_arguments = super().iterate_packed_arguments()
-        if not self.is_kw_only() or not self.request_type_annotation:
+        if not self.is_kw_only() or not self.has_request_type_annotation():
             yield from packed_arguments
             return
 
@@ -62,9 +61,3 @@ class Method(Function):
             return super().has_arguments()
 
         return len(self.arguments) > 1
-
-    def iterate_argument_type_annotations(self) -> Generator[FakeAnnotation]:
-        """
-        Iterate over argument type annotations.
-        """
-        return (argument.type_annotation for argument in self.arguments if argument.type_annotation)

--- a/mypy_boto3_builder/structures/packages/service_package.py
+++ b/mypy_boto3_builder/structures/packages/service_package.py
@@ -118,7 +118,7 @@ class ServicePackage(Package):
             result.add(type_annotation)
 
         for method in self._iterate_methods():
-            if not method.request_type_annotation:
+            if not method.has_request_type_annotation():
                 continue
             result.add(method.request_type_annotation)
 

--- a/mypy_boto3_builder/templates/common/method.md.jinja2
+++ b/mypy_boto3_builder/templates/common/method.md.jinja2
@@ -3,7 +3,7 @@ Asynchronous method. Use `await {{ method.name }}(...)` for a synchronous call.
 {% endif %}
 
 {% if method.has_arguments() %}
-{% if method.request_type_annotation %}
+{% if method.has_request_type_annotation() %}
 Arguments mapping described in {% with type_annotation=method.request_type_annotation %}{% include "common/type_annotation.md.jinja2" with context -%}{% endwith -%}.
 {% endif %}
 {% if method.is_kw_only() %}Keyword-only arguments:{% else %}Arguments:{% endif %}

--- a/mypy_boto3_builder/templates/common/method_code.md.jinja2
+++ b/mypy_boto3_builder/templates/common/method_code.md.jinja2
@@ -16,7 +16,7 @@
 {{ '\n' -}}
 {% endfor -%}
 
-{% if method.request_type_annotation -%}
+{% if method.has_request_type_annotation() -%}
 {{ '\n\n' -}}
 ```python
 # {{ method.name }} method usage example with argument unpacking

--- a/tests/parsers/test_shape_parser.py
+++ b/tests/parsers/test_shape_parser.py
@@ -188,7 +188,7 @@ class TestShapeParser:
         assert shape_parser._output_typed_dict_map["TestOutputTypeDef"].name == "TestOutputTypeDef"
         assert shape_parser._output_typed_dict_map["TestOutputTypeDef"].has_optional() is False
         assert (
-            shape_parser._response_typed_dict_map["Test2ExtraResponseTypeDef"].has_optional()
+            shape_parser._response_typed_dict_map["Test2ResponseExtraTypeDef"].has_optional()
             is False
         )
 


### PR DESCRIPTION
### Changed
- `[services]` TypeDefs for packed method arguments use shorter names if possible `CreateDistributionRequestRequestTypeDef` -> `CreateDistributionRequestTypeDef`

### Fixed
- `[services]` All methods argument accept output types as input (reported by @chaos95 in #348)
- `[builder]` Input types replacement with `input | output` unions is significantly faster
