### PR TITLE
Feat/tune required vs not required attributes

### DIFF
--- a/mypy_boto3_builder/parsers/shape_parser.py
+++ b/mypy_boto3_builder/parsers/shape_parser.py
@@ -56,7 +56,7 @@ from mypy_boto3_builder.type_maps.method_type_map import (
     get_default_value_stub,
     get_method_type_stub,
 )
-from mypy_boto3_builder.type_maps.required_attribute_map import is_required
+from mypy_boto3_builder.type_maps.required_attribute_map import get_attribute_required_override
 from mypy_boto3_builder.type_maps.shape_type_map import (
     get_output_shape_type_stub,
     get_shape_type_stub,
@@ -487,6 +487,7 @@ class ShapeParser:
         typed_dict_map[resource_typed_dict_name] = typed_dict
 
         for attr_name, attr_shape in shape.members.items():
+            is_required = (attr_name in required) if required else True
             typed_dict.add_attribute(
                 attr_name,
                 self.parse_shape(
@@ -495,7 +496,7 @@ class ShapeParser:
                     is_output_child=is_output_or_child,
                     is_streaming=is_streaming,
                 ),
-                required=attr_name in required,
+                required=is_required,
             )
         if output:
             self._mark_typed_dict_as_total(typed_dict)
@@ -512,14 +513,18 @@ class ShapeParser:
 
     def _mark_typed_dict_as_total(self, typed_dict: TypeTypedDict) -> None:
         for attribute in typed_dict.children:
-            if is_required(self.service_name, typed_dict.name, attribute.name):
-                attribute.mark_as_required()
-            else:
+            override_is_required = get_attribute_required_override(
+                self.service_name, typed_dict.name, attribute.name
+            )
+
+            if override_is_required is None:
                 attribute_rendered = attribute.get_type_annotation().render()
                 self.logger.debug(
                     f"Leaving output {typed_dict.name}.{attribute.name} as {attribute_rendered}",
                     tags=(typed_dict.name, attribute.name, attribute_rendered),
                 )
+            else:
+                attribute.set_required(override_is_required)
 
     def _add_response_metadata(self, typed_dict: TypeTypedDict) -> None:
         child_names = {i.name for i in typed_dict.children}

--- a/mypy_boto3_builder/type_annotations/type_typed_dict.py
+++ b/mypy_boto3_builder/type_annotations/type_typed_dict.py
@@ -81,11 +81,11 @@ class TypedDictAttribute:
         """
         return self.required
 
-    def mark_as_required(self) -> None:
+    def set_required(self, required: bool) -> None:  # noqa: FBT001
         """
-        Mark attribute as required.
+        Update whether an attribute is required.
         """
-        self.required = True
+        self.required = required
 
 
 class TypeTypedDict(TypeParent, TypeDefSortable):

--- a/mypy_boto3_builder/type_maps/required_attribute_map.py
+++ b/mypy_boto3_builder/type_maps/required_attribute_map.py
@@ -11,7 +11,7 @@ from mypy_boto3_builder.constants import ALL
 from mypy_boto3_builder.service_name import ServiceName, ServiceNameCatalog
 from mypy_boto3_builder.utils.lookup_dict import LookupDict
 
-# Mapping reresenting Required/NotRequired keys of output botocore shapes.
+# Mapping representing Required/NotRequired keys of output botocore shapes.
 # ServiceName -> TypedDict name -> Argument name -> is_required (True/False)
 # False means that argument should be marked as NotRequired.
 # True means that argument should be marked as Required.
@@ -30,6 +30,12 @@ REQUIRED_ATTRIBUTE_MAP: Final[Mapping[ServiceName, Mapping[str, Mapping[str, boo
     ServiceNameCatalog.dynamodb: {
         ALL: {
             "LastEvaluatedKey": False,
+        },
+    },
+    ServiceNameCatalog.sqs: {
+        "ChangeMessageVisibilityBatchResultTypeDef": {
+            "Successful": False,
+            "Failed": False,
         },
     },
     ServiceNameCatalog.stepfunctions: {
@@ -54,9 +60,11 @@ _LOOKUP: LookupDict[bool] = LookupDict(
 )
 
 
-def is_required(service_name: ServiceName, typed_dict_name: str, argument_name: str) -> bool:
+def get_attribute_required_override(
+    service_name: ServiceName, typed_dict_name: str, argument_name: str
+) -> bool | None:
     """
-    Check if output shape argument should be marked as NotRequired.
+    Return the optional override value for an attribute.
 
     Arguments:
         service_name -- Service name.
@@ -64,7 +72,7 @@ def is_required(service_name: ServiceName, typed_dict_name: str, argument_name: 
         attribute_name -- Target attribute name.
 
     Returns:
-        Literal children or None.
+        True or False if the field should be overridden to Required or NotRequired accordingly.
+        If no override is set, returns None.
     """
-    is_required = _LOOKUP.get(service_name.name, typed_dict_name, argument_name)
-    return True if is_required is None else is_required
+    return _LOOKUP.get(service_name.name, typed_dict_name, argument_name)

--- a/tests/parsers/test_shape_parser.py
+++ b/tests/parsers/test_shape_parser.py
@@ -1,9 +1,15 @@
+from collections.abc import Iterator
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+from pytest_mock import MockerFixture
+
+from mypy_boto3_builder.parsers.resource_loader import ResourceLoader
 from mypy_boto3_builder.parsers.shape_parser import ShapeParser, TypedDictMap
 from mypy_boto3_builder.service_name import ServiceName, ServiceNameCatalog
 from mypy_boto3_builder.type_annotations.type import Type
 from mypy_boto3_builder.type_annotations.type_typed_dict import TypedDictAttribute, TypeTypedDict
+from mypy_boto3_builder.utils.boto3_utils import get_botocore_session
 
 
 class TestShapeParser:
@@ -272,3 +278,41 @@ class TestShapeParser:
         }
         result = self.shape_parser.get_resource_method_map("c")
         assert len(result.keys()) == 4
+
+
+@pytest.fixture
+def _real_botocore_session(mocker: MockerFixture) -> Iterator[None]:
+    """Undo the autouse botocore session mock so ShapeParser uses real service data."""
+    mocker.stopall()
+    ResourceLoader._botocore_session = None
+    ResourceLoader._loader = None
+    get_botocore_session.cache_clear()
+    yield
+    ResourceLoader._botocore_session = None
+    ResourceLoader._loader = None
+    get_botocore_session.cache_clear()
+
+
+@pytest.mark.usefixtures("_real_botocore_session")
+def test_sqs_change_message_visibility_batch_not_required() -> None:
+    shape_parser = ShapeParser(ServiceNameCatalog.sqs)
+    shape_parser.get_client_method_map()
+    typed_dict = shape_parser._response_typed_dict_map[
+        "ChangeMessageVisibilityBatchResultTypeDef"
+    ]
+    failed_attrs = [c for c in typed_dict.children if c.name == "Failed"]
+    assert len(failed_attrs) == 1
+    assert not failed_attrs[0].is_required()
+
+
+@pytest.mark.usefixtures("_real_botocore_session")
+def test_sagemaker_describe_training_job_failure_reason_not_required() -> None:
+    service_name = ServiceName("sagemaker", "SageMaker")
+    shape_parser = ShapeParser(service_name)
+    shape_parser.get_client_method_map()
+    typed_dict = shape_parser._response_typed_dict_map[
+        "DescribeTrainingJobResponseTypeDef"
+    ]
+    failure_reason_attrs = [c for c in typed_dict.children if c.name == "FailureReason"]
+    assert len(failure_reason_attrs) == 1
+    assert not failure_reason_attrs[0].is_required()

--- a/tests/type_annotations/test_type_typed_dict.py
+++ b/tests/type_annotations/test_type_typed_dict.py
@@ -16,11 +16,13 @@ class TestTypedDictAttribute:
     def test_render(self) -> None:
         assert self.result.render() == '"test": dict[str, Any]'
 
-    def test_mark_as_required(self) -> None:
+    def test_set_required(self) -> None:
         self.result.required = False
         assert not self.result.is_required()
-        self.result.mark_as_required()
+        self.result.set_required(True)
         assert self.result.is_required()
+        self.result.set_required(False)
+        assert not self.result.is_required()
 
 
 class TestTypeTypedDict:

--- a/tests/type_maps/test_required_attribute_map.py
+++ b/tests/type_maps/test_required_attribute_map.py
@@ -1,17 +1,48 @@
 from mypy_boto3_builder.service_name import ServiceNameCatalog
-from mypy_boto3_builder.type_maps.required_attribute_map import is_required
+from mypy_boto3_builder.type_maps.required_attribute_map import get_attribute_required_override
 
 
-def test_is_required() -> None:
-    assert is_required(ServiceNameCatalog.ec2, "RandomTypeDef", "PaginationToken") is False
-    assert is_required(ServiceNameCatalog.dynamodb, "RandomTypeDef", "Key") is True
-    assert is_required(ServiceNameCatalog.dynamodb, "RandomTypeDef", "LastEvaluatedKey") is False
-    assert is_required(ServiceNameCatalog.stepfunctions, "RandomTypeDef", "stopDate") is True
+def test_get_attribute_required_override() -> None:
     assert (
-        is_required(ServiceNameCatalog.stepfunctions, "DescribeExecutionOutputTypeDef", "stopDate")
+        get_attribute_required_override(ServiceNameCatalog.ec2, "RandomTypeDef", "PaginationToken")
         is False
     )
     assert (
-        is_required(ServiceNameCatalog.stepfunctions, "DescribeExecutionOutputTypeDef", "Date")
-        is True
+        get_attribute_required_override(ServiceNameCatalog.dynamodb, "RandomTypeDef", "Key") is None
+    )
+    assert (
+        get_attribute_required_override(
+            ServiceNameCatalog.dynamodb, "RandomTypeDef", "LastEvaluatedKey"
+        )
+        is False
+    )
+    assert (
+        get_attribute_required_override(
+            ServiceNameCatalog.stepfunctions, "RandomTypeDef", "stopDate"
+        )
+        is None
+    )
+    assert (
+        get_attribute_required_override(
+            ServiceNameCatalog.stepfunctions, "DescribeExecutionOutputTypeDef", "stopDate"
+        )
+        is False
+    )
+    assert (
+        get_attribute_required_override(
+            ServiceNameCatalog.stepfunctions, "DescribeExecutionOutputTypeDef", "Date"
+        )
+        is None
+    )
+    assert (
+        get_attribute_required_override(
+            ServiceNameCatalog.sqs, "ChangeMessageVisibilityBatchResultTypeDef", "Successful"
+        )
+        is False
+    )
+    assert (
+        get_attribute_required_override(
+            ServiceNameCatalog.sqs, "ChangeMessageVisibilityBatchResultTypeDef", "Failed"
+        )
+        is False
     )


### PR DESCRIPTION
### Notes

I have changed the logic of Required vs NotRequired marking on TypedDicts to be more refined.
The code now assumes that any type that contains a non-empty list of required attributes implies all non-mentioned attributes are NotRequired.
In addition, the existing mapping of required attributes was converted to act as an override in both directions, where True => Required and False => NotRequired, whereas previously it was only single direction True => Required.

I've implemented those changes initially because I noticed that the SQS response for ChangeMessageVisibilityBatch was incorrect in AWS's own documentation, and I encountered this as a runtime error with a missing key error. I changed the override logic to be able to document that into the type, even though AWS failed to do so with their botocore shape.
I then identified that in many cases the logic falsely assumed other attributes are required when they aren't specified as such by AWS.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

All of these are optional:

- [x] I have performed a self-review of my own code
- [x] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project (PLEASE NOTE: it was not ran by many other people, so I ran the relevant checks only over my own changes, this script fails on existing code already)
- [x] I have tested my code changes

Thank you!
