### PR TITLE
Deprecate boto3-stubs package family

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Mypy Boto3 Builder
 
 [![PyPI - mypy-boto3-builder](https://img.shields.io/pypi/v/mypy-boto3-builder.svg?color=blue&label=mypy-boto3-builder)](https://pypi.org/project/mypy-boto3-builder)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/boto3-stubs.svg?color=blue)](https://pypi.org/project/boto3-stubs)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/types-boto3.svg?color=blue)](https://pypi.org/project/types-boto3)
 [![Docs](https://img.shields.io/readthedocs/mypy-boto3-builder.svg?color=blue&label=builder%20docs)](https://youtype.github.io/mypy_boto3_builder/)
 
-[![PyPI - boto3-stubs](https://img.shields.io/pypi/v/boto3-stubs.svg?color=blue&label=boto3-stubs)](https://pypi.org/project/boto3-stubs)
+[![PyPI - types-boto3](https://img.shields.io/pypi/v/types-boto3.svg?color=blue&label=types-boto3)](https://pypi.org/project/types-boto3)
 [![PyPI - boto3](https://img.shields.io/pypi/v/boto3.svg?color=blue&label=boto3)](https://pypi.org/project/boto3)
-[![Docs](https://img.shields.io/readthedocs/boto3-stubs.svg?color=blue&label=boto3-stubs%20docs)](https://youtype.github.io/boto3_stubs_docs/)
-[![PyPI - Downloads](https://static.pepy.tech/badge/boto3-stubs)](https://pepy.tech/project/boto3-stubs)
-[![PyPI - Monthly Downloads](https://img.shields.io/pypi/dm/boto3-stubs?color=blue)](https://pypistats.org/packages/boto3-stubs)
+[![Docs](https://img.shields.io/readthedocs/types-boto3.svg?color=blue&label=types-boto3%20docs)](https://youtype.github.io/types_boto3_docs/)
+[![PyPI - Downloads](https://static.pepy.tech/badge/types-boto3)](https://pepy.tech/project/types-boto3)
+[![PyPI - Monthly Downloads](https://img.shields.io/pypi/dm/types-boto3?color=blue)](https://pypistats.org/packages/types-boto3)
 
 [![PyPI - types-aiobotocore](https://img.shields.io/pypi/v/types-aiobotocore.svg?color=blue&label=types-aiobotocore)](https://pypi.org/project/types-aiobotocore)
 [![PyPI - aiobotocore](https://img.shields.io/pypi/v/aiobotocore.svg?color=blue&label=aiobotocore)](https://pypi.org/project/aiobotocore)
@@ -25,9 +25,14 @@
 ![boto3.typed](https://github.com/youtype/mypy_boto3_builder/raw/main/logo.png)
 
 Type annotations generator for [types-boto3](https://pypi.org/project/types-boto3/),
-[boto3-stubs](https://pypi.org/project/boto3-stubs/),
 [types-aiobotocore](https://pypi.org/project/types-aiobotocore/),
 and [types-aioboto3](https://pypi.org/project/types-aioboto3/) projects.
+
+The `boto3-stubs` package family is deprecated in favor of `types-boto3`. Every
+`boto3-stubs` package is 100% equivalent and fully compatible with its `types-boto3`
+counterpart, so existing projects can switch package names without changing imports or type
+annotations.
+
 Compatible with
 [VSCode](https://code.visualstudio.com/),
 [PyCharm](https://www.jetbrains.com/pycharm/),
@@ -41,7 +46,7 @@ See how it helps to find and fix potential bugs:
 
 ![types-boto3 demo](https://raw.githubusercontent.com/youtype/mypy_boto3_builder/main/demo.gif)
 
-Do you want more? Check the [documentation](https://youtype.github.io/boto3_stubs_docs/) and use `boto3` like a pro!
+Do you want more? Check the [documentation](https://youtype.github.io/types_boto3_docs/) and use `boto3` like a pro!
 
 - [Mypy Boto3 Builder](#mypy-boto3-builder)
   - [Quickstart](#quickstart)

--- a/docsmd/index.md
+++ b/docsmd/index.md
@@ -1,9 +1,14 @@
 # Mypy Boto3 Builder
 
 Type annotations generator for [types-boto3](https://pypi.org/project/types-boto3/),
-[boto3-stubs](https://pypi.org/project/boto3-stubs/),
 [types-aiobotocore](https://pypi.org/project/types-aiobotocore/),
 and [types-aioboto3](https://pypi.org/project/types-aioboto3/) projects.
+
+The `boto3-stubs` package family is deprecated in favor of `types-boto3`. Every
+`boto3-stubs` package is 100% equivalent and fully compatible with its `types-boto3`
+counterpart, so existing projects can switch package names without changing imports or type
+annotations.
+
 Compatible with
 [VSCode](https://code.visualstudio.com/),
 [PyCharm](https://www.jetbrains.com/pycharm/),
@@ -22,7 +27,6 @@ See how it helps to find and fix potential bugs:
   - [Type annotations documentation](#type-annotations-documentation)
   - [Versioning](#versioning)
   - [Latest changes](#latest-changes)
-
 
 ## Quickstart
 

--- a/docsmd/pre_build.md
+++ b/docsmd/pre_build.md
@@ -5,8 +5,11 @@
   - [aiobotocore](#aiobotocore)
   - [aioboto3](#aioboto3)
 
-
 ## boto3 and botocore
+
+Use the `types-boto3` package family for new and existing projects. The legacy `boto3-stubs`
+packages are deprecated; they are 100% equivalent and fully compatible with the corresponding
+`types-boto3` packages.
 
 Check [types-boto3](https://pypi.org/project/types-boto3/) project for installation
 and usage instructions.

--- a/mypy_boto3_builder/cli_parser.py
+++ b/mypy_boto3_builder/cli_parser.py
@@ -168,7 +168,7 @@ def parse_args(args: Sequence[str]) -> CLINamespace:
         action=EnumListAction,
         metavar="PRODUCT",
         nargs="+",
-        default=(Product.boto3_stubs, Product.boto3_stubs_services),
+        default=(Product.types_boto3, Product.types_boto3_services),
         help="Package to generate.",
     )
     parser.add_argument(

--- a/mypy_boto3_builder/package_data.py
+++ b/mypy_boto3_builder/package_data.py
@@ -61,6 +61,9 @@ class BasePackageData(ABC):
     # is the package released to conda-forge
     is_conda_forge_supported: bool = False
 
+    # preferred PyPI replacement for a deprecated package
+    replacement_pypi_name: str = ""
+
     def get_service_package_name(self, service_name: ServiceName) -> str:
         """
         Get service package name.
@@ -266,6 +269,7 @@ class Boto3StubsPackageData(BasePackageData):
     )
     is_vscode_supported: bool = True
     is_conda_forge_supported: bool = True
+    replacement_pypi_name: str = TypesBoto3PackageData.pypi_name
 
     def _get_library_version(self) -> str:
         return get_boto3_version()
@@ -279,6 +283,7 @@ class Boto3StubsLitePackageData(Boto3StubsPackageData):
 
     pypi_name: str = Boto3StubsPackageData.pypi_lite_name
     pypi_lite_name: str = ""
+    replacement_pypi_name: str = TypesBoto3PackageData.pypi_lite_name
 
 
 @dataclass(kw_only=True)
@@ -291,6 +296,7 @@ class Boto3StubsFullPackageData(Boto3StubsPackageData):
     pypi_name: str = Boto3StubsPackageData.pypi_full_name
     is_conda_forge_supported: bool = False
     install_requires: tuple[str, ...] = ()
+    replacement_pypi_name: str = TypesBoto3PackageData.pypi_full_name
 
     def get_service_pypi_name(self, service_name: ServiceName) -> str:
         """
@@ -307,6 +313,7 @@ class Boto3StubsCustomPackageData(Boto3StubsPackageData):
 
     pypi_name: str = Boto3StubsPackageData.pypi_custom_name
     is_conda_forge_supported: bool = False
+    replacement_pypi_name: str = TypesBoto3PackageData.pypi_custom_name
 
     def get_service_pypi_name(self, service_name: ServiceName) -> str:
         """

--- a/mypy_boto3_builder/structures/package.py
+++ b/mypy_boto3_builder/structures/package.py
@@ -147,6 +147,33 @@ class Package:
         """
         return self.data.local_doc_link
 
+    @property
+    def replacement_pypi_name(self) -> str:
+        """
+        Preferred replacement for a deprecated PyPI package.
+        """
+        if not self.data.replacement_pypi_name:
+            return ""
+
+        if self.pypi_name == self.data.pypi_name:
+            return self.data.replacement_pypi_name
+
+        service_pypi_prefix = f"{self.data.service_pypi_prefix}-"
+        if not self.pypi_name.startswith(service_pypi_prefix):
+            return ""
+
+        service_name = self.pypi_name.removeprefix(service_pypi_prefix)
+        return f"{self.data.replacement_pypi_name}-{service_name}"
+
+    @property
+    def replacement_import_name(self) -> str:
+        """
+        Import name for the preferred service package replacement.
+        """
+        if self.pypi_name == self.data.pypi_name:
+            return ""
+        return self.replacement_pypi_name.replace("-", "_")
+
     def get_service_local_doc_link(self, service_name: ServiceName) -> str:
         """
         Get link to service local docs.
@@ -195,7 +222,11 @@ class Package:
         Get classifiers for package.
         """
         result = [
-            "Development Status :: 5 - Production/Stable",
+            (
+                "Development Status :: 7 - Inactive"
+                if self.replacement_pypi_name
+                else "Development Status :: 5 - Production/Stable"
+            ),
             "Intended Audience :: Developers",
             "Environment :: Console",
             "Natural Language :: English",

--- a/mypy_boto3_builder/structures/packages/wrapper_package.py
+++ b/mypy_boto3_builder/structures/packages/wrapper_package.py
@@ -85,7 +85,10 @@ class WrapperPackage(Package, ABC):
         """
         Get short description for the package.
         """
-        return (
+        description = (
             f"{prefix} for {self.library_name} {self.library_version}"
             f" generated with {PACKAGE_NAME} {get_builder_version()}"
         )
+        if self.replacement_pypi_name:
+            return f"Deprecated: {description}. Use {self.replacement_pypi_name} instead"
+        return description

--- a/mypy_boto3_builder/templates/common/header.md.jinja2
+++ b/mypy_boto3_builder/templates/common/header.md.jinja2
@@ -1,5 +1,25 @@
 # {{ package.pypi_name }}
 
+{% if package.replacement_pypi_name -%}
+## Deprecated
+
+**This package is deprecated. Use
+[{{ package.replacement_pypi_name }}](https://pypi.org/project/{{ package.replacement_pypi_name }}/)
+instead.**
+
+{% if package.replacement_import_name -%}
+`{{ package.pypi_name }}` and `{{ package.replacement_pypi_name }}` provide **equivalent type
+annotations** and are fully compatible with the same `{{ package.library_name }}` version.
+To migrate, replace the package name in your dependencies and change imports from
+`{{ package.name }}` to `{{ package.replacement_import_name }}`.
+{% else -%}
+`{{ package.pypi_name }}` and `{{ package.replacement_pypi_name }}` are **100% equivalent and
+fully compatible**.
+You can switch to `{{ package.replacement_pypi_name }}` without changing any imports or type
+annotations.
+{% endif %}
+
+{% endif -%}
 [![PyPI - {{ package.pypi_name }}]({{ package.url.pypi_badge }})]({{ package.url.pypi }})
 [![PyPI - Python Version]({{ package.url.pyversions_badge }})]({{ package.url.pypi }})
 [![Docs]({{ package.url.rtd_badge }})]({{ package.url.docs }})

--- a/mypy_boto3_builder/templates/common/service/pyproject.toml.jinja2
+++ b/mypy_boto3_builder/templates/common/service/pyproject.toml.jinja2
@@ -7,7 +7,7 @@ name = "{{ package.pypi_name }}"
 version = "{{ package.version }}"
 license = "MIT"
 authors = [{ name = "Vlad Emelianov", email = "vlad.emelianov.nz@gmail.com" }]
-description = "Type annotations for {{ package.library_name }} {{ service_name.class_name }} {{ package.library_version }} service generated with {{ builder_package_name }} {{ builder_version }}"
+description = "{% if package.replacement_pypi_name %}Deprecated: {% endif %}Type annotations for {{ package.library_name }} {{ service_name.class_name }} {{ package.library_version }} service generated with {{ builder_package_name }} {{ builder_version }}{% if package.replacement_pypi_name %}. Use {{ package.replacement_pypi_name }} instead{% endif %}"
 readme = "README.md"
 classifiers = [
 {%- for classifier in package.get_classifiers() -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mypy-boto3-builder"
 version = "8.12.0"
 requires-python = ">=3.12"
-description = "Type annotations generator for types-boto3, boto3-stubs, types-aiobotocore, and types-aioboto3."
+description = "Type annotations generator for types-boto3, types-aiobotocore, and types-aioboto3."
 authors = [{ name = "Vlad Emelianov", email = "vlad.emelianov.nz@gmail.com" }]
 license = { file = "LICENSE" }
 readme = "README.md"
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 build = ["setuptools"]
-check = ["boto3-stubs", "types-aiobotocore", "types-aioboto3"]
+check = ["types-boto3", "types-aiobotocore", "types-aioboto3"]
 
 [dependency-groups]
 typecheck = ["pyright", "mypy"]

--- a/tests/structures/pacakges/test_service_package.py
+++ b/tests/structures/pacakges/test_service_package.py
@@ -41,6 +41,8 @@ class TestServicePackage:
     def test_init(self) -> None:
         assert self.service_package.name == "mypy_boto3_s3"
         assert self.service_package.pypi_name == "mypy-boto3-s3"
+        assert self.service_package.replacement_pypi_name == "types-boto3-s3"
+        assert self.service_package.replacement_import_name == "types_boto3_s3"
 
     def test_client(self) -> None:
         assert self.service_package.client.name == "Client"

--- a/tests/structures/test_package.py
+++ b/tests/structures/test_package.py
@@ -23,6 +23,8 @@ class TestPackage:
         )
         assert package.get_module_name(ServiceNameCatalog.s3) == "mypy_boto3_s3"
         assert package.get_service_pypi_name(ServiceNameCatalog.s3) == "mypy-boto3-s3"
+        assert package.replacement_pypi_name == "types-boto3"
+        assert not package.replacement_import_name
         assert package.essential_service_names == [ServiceNameCatalog.s3]
         assert package.min_python_version
         assert str(package) == "boto3-stubs 2.3.4 (boto3 1.2.3)"
@@ -41,3 +43,4 @@ class TestPackage:
         assert "Programming Language :: Python :: 3" in classifiers
         assert "Programming Language :: Python :: 3.13" in classifiers
         assert "Programming Language :: Python :: 3 :: Only" in classifiers
+        assert "Development Status :: 7 - Inactive" in classifiers

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,12 +38,12 @@ class TestMain:
             ] == ["ec2", "ecs"]
 
     @patch("mypy_boto3_builder.main.get_available_service_names")
-    @patch("mypy_boto3_builder.main.Boto3Generator")
+    @patch("mypy_boto3_builder.main.TypesBoto3Generator")
     @patch.object(sys, "argv", ["-o", "/tmp", "-b", "1.2.3.post4"])  # noqa: S108
     def test_main(
         self,
-        Boto3GeneratorMock: MagicMock,
+        TypesBoto3GeneratorMock: MagicMock,
         get_available_service_names_mock: MagicMock,
     ) -> None:
         main()
-        Boto3GeneratorMock().generate_product.assert_called()
+        TypesBoto3GeneratorMock().generate_product.assert_called()

--- a/uv.lock
+++ b/uv.lock
@@ -133,19 +133,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3-stubs"
-version = "1.40.69"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/f7/10c3314c273fcd74bbf588c521cd30cba5784c492ba14858014bdd295af3/boto3_stubs-1.40.69.tar.gz", hash = "sha256:244121672c614b58426f1630f5685a821f4a8cff49deed59a287d9d91c7a4d64", size = 99409, upload-time = "2025-11-08T08:35:02.954Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/54/1f5d5db7812524809656baadc63669f4456a88bc65f1b30b576f3d2309f9/boto3_stubs-1.40.69-py3-none-any.whl", hash = "sha256:004e9647c310dcaec45145645dfa9aec73fb233f2649900eeaa976894378d57c", size = 68982, upload-time = "2025-11-08T08:34:57.269Z" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.40.69"
 source = { registry = "https://pypi.org/simple" }
@@ -925,9 +912,9 @@ build = [
     { name = "setuptools" },
 ]
 check = [
-    { name = "boto3-stubs" },
     { name = "types-aioboto3" },
     { name = "types-aiobotocore" },
+    { name = "types-boto3" },
 ]
 
 [package.dev-dependencies]
@@ -965,7 +952,6 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "boto3" },
-    { name = "boto3-stubs", marker = "extra == 'check'" },
     { name = "botocore" },
     { name = "jinja2" },
     { name = "loguru" },
@@ -979,6 +965,7 @@ requires-dist = [
     { name = "setuptools", marker = "extra == 'build'" },
     { name = "types-aioboto3", marker = "extra == 'check'" },
     { name = "types-aiobotocore", marker = "extra == 'check'" },
+    { name = "types-boto3", marker = "extra == 'check'" },
 ]
 provides-extras = ["build", "check"]
 


### PR DESCRIPTION
### Notes

As discussed in #364, it is very confusing that the `types-boto3` and `boto3-stubs` packages are identical in content and exist in parallel. Also, downstream package maintainers like me on conda-forge have duplicate maintenance work in updating both variants. Maintaining two differently named versions of the same package doesn't provide any benefit.

Therefore, I propose to deprecate the `boto3-stubs` and `boto3-stubs-*` package variants to nudge downstream maintainers to migrate to the `types-boto3` variants, which is the name you [recommend](https://github.com/youtype/mypy_boto3_builder/issues/364#issuecomment-3393648627).

The `boto3-stubs` packages are still updated, but I recommend stopping doing so in maybe 6-12 months. This gives downstream maintainers enough time to make the (fairly trivial) change.

Closes #364.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Deprecation

### Checklist

All of these are optional:

- [x] I have performed a self-review of my own code
- [ ] I have run `./scripts/before_commit.sh` to follow the style guidelines of this project - No, this fails because of 106 pre-existing errors.
- [x] I have tested my code changes

### AI Note

I used Codex (GPT-5.6-Sol) to help draft this PR, and I also conducted a self-review.